### PR TITLE
fix: initialize OCR engine once at module level 

### DIFF
--- a/examples/autonomous_agents/expense_tracker_bot/tools.py
+++ b/examples/autonomous_agents/expense_tracker_bot/tools.py
@@ -1,48 +1,39 @@
-import glob
 import os
-import tempfile
 
 from upsonic.ocr import OCR
 from upsonic.ocr.layer_1.engines import EasyOCREngine
 from upsonic.tools.config import tool
 
 
-def _find_latest_telegram_image() -> str | None:
-    """Find the most recently created telegram_media temp file."""
-    tmp_dir = tempfile.gettempdir()
-    candidates = glob.glob(os.path.join(tmp_dir, "telegram_media_*"))
-    if not candidates:
-        return None
-    return max(candidates, key=os.path.getmtime)
+_engine = EasyOCREngine(languages=["en", "tr"], gpu=False, rotation_fix=True)
+_ocr = OCR(layer_1_ocr_engine=_engine)
+
+WORKSPACE: str = os.path.join(os.path.dirname(__file__), "workspace")
 
 
-@tool
-def ocr_extract_text(image_path: str = "") -> str:
-    """Extracts text from receipt/invoice photos sent by the user.
+@tool(timeout=300.0)
+def ocr_extract_text(image_path: str) -> str:
+    """Extracts text from a receipt image (PNG, JPG) using OCR.
 
-    Reads text in the image using EasyOCR and returns it with confidence scores.
-    Call this tool when the user sends a photo from Telegram.
-    image_path can be left empty; the system will automatically find the incoming photo's path.
+    Use this for image files. For PDFs, read them directly — no need to call this tool.
 
     Args:
-        image_path: Image file path (can be left empty, auto-detected)
+        image_path: Absolute or workspace-relative path to the image file.
 
     Returns:
-        OCR result: extracted text blocks, confidence scores, and average confidence score
+        Extracted text blocks with confidence scores, or an error message.
     """
-    if not image_path or not os.path.isfile(image_path):
-        discovered = _find_latest_telegram_image()
-        if discovered:
-            image_path = discovered
-        else:
-            return "ERROR: No image found to process. Please send a photo again."
+    # Resolve workspace-relative paths
+    if not os.path.isabs(image_path):
+        image_path = os.path.join(WORKSPACE, image_path)
+
+    if not os.path.isfile(image_path):
+        return f"ERROR: File not found: {image_path}"
 
     try:
-        engine = EasyOCREngine(languages=["tr"], gpu=False, rotation_fix=True)
-        ocr = OCR(layer_1_ocr_engine=engine)
-        result = ocr.process_file(image_path)
+        result = _ocr.process_file(image_path)
     except Exception as e:
-        return f"ERROR: OCR operation failed: {e}"
+        return f"ERROR: OCR failed: {e}"
 
     lines = []
     total_confidence = 0.0
@@ -58,17 +49,12 @@ def ocr_extract_text(image_path: str = "") -> str:
         lines.append(f"[{conf:.0%}] {text}")
 
     if block_count == 0:
-        return "OCR could not detect any text. The image may not be clear."
+        return "OCR could not detect any text. The image may be unclear or empty."
 
     avg_confidence = total_confidence / block_count
-
-    output = f"=== OCR Result (Average Confidence: {avg_confidence:.0%}) ===\n"
-    output += "\n".join(lines)
+    output = f"=== OCR Result (avg confidence: {avg_confidence:.0%}) ===\n" + "\n".join(lines)
 
     if avg_confidence < 0.6:
-        output += (
-            "\n\nWARNING: OCR confidence score is low (<60%). "
-            "Results may be incorrect, ask the user for confirmation."
-        )
+        output += "\n\nWARNING: Low confidence (<60%). Results may be inaccurate."
 
     return output


### PR DESCRIPTION
Moves OCR engine init to module level so models load once, not on every call. Adds WORKSPACE constant for relative path resolution and removes Telegram auto-detection logic. 